### PR TITLE
ci: add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on:
+  push:
+    branches: [main, staging, dev]
+  pull_request:
+    branches: [main, staging, dev]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx vitest --run
+        env:
+          VITE_API_URL: http://localhost:8000
+          VITE_NAME: teledash
+          VITE_VERSION: 0.0.0-test


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate running tests on pushes and pull requests to the main, staging, and dev branches. The workflow sets up a Node.js environment, installs dependencies, and runs the test suite using Vitest.

Testing automation:

* Added a `.github/workflows/test.yml` workflow that triggers on pushes and pull requests to `main`, `staging`, and `dev`, sets up Node.js 22, installs dependencies with `npm ci`, and runs tests with `npx vitest --run`.Run vitest on push and PR to main, staging, and dev branches.