### PR TITLE
chore(dependabot): target dev branch for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,6 @@ version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
+    target-branch: "dev"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This pull request makes a minor configuration change to the Dependabot settings, specifying that dependency update pull requests should target the `dev` branch instead of the default branch.

* Updated `.github/dependabot.yml` to set `target-branch` to `dev` for npm dependencies.