### PR TITLE
feat(chats): add delete chat button to chat list

### DIFF
--- a/src/features/chats/api/deleteChat.ts
+++ b/src/features/chats/api/deleteChat.ts
@@ -1,0 +1,41 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { axios } from "lib/axios";
+import { MutationConfig } from "lib/react-query";
+
+import { DeleteChatResponse } from "types";
+
+export type DeleteChatParams = {
+  id: number;
+  leave?: boolean;
+  delete?: boolean;
+  attachments?: boolean;
+};
+
+export const deleteChat = ({
+  id,
+  ...params
+}: DeleteChatParams): Promise<DeleteChatResponse> => {
+  return axios.delete(`/chats/${id}`, { params });
+};
+
+type UseDeleteChatOptions = {
+  mutationConfig?: MutationConfig<typeof deleteChat>;
+};
+
+export const useDeleteChat = ({
+  mutationConfig,
+}: UseDeleteChatOptions = {}) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...restConfig } = mutationConfig ?? {};
+
+  return useMutation({
+    onSuccess: (...args) => {
+      queryClient.refetchQueries({ queryKey: ["chats"] });
+      onSuccess?.(...args);
+    },
+    ...restConfig,
+    mutationFn: deleteChat,
+  });
+};

--- a/src/features/chats/api/index.ts
+++ b/src/features/chats/api/index.ts
@@ -1,3 +1,4 @@
+export * from "./deleteChat";
 export * from "./getChat";
 export * from "./getChats";
 export * from "./getChatsStats";

--- a/src/features/chats/components/ChatList.tsx
+++ b/src/features/chats/components/ChatList.tsx
@@ -15,6 +15,7 @@ import {
   ChatListTags,
   ChatSortSelector,
   createChatBadgesArray,
+  DeleteChat,
   TooltipChatLink,
   useChats,
 } from "features/chats";
@@ -65,7 +66,7 @@ const ChatListItem = (props: Chat) => {
       : undefined;
 
   return (
-    <li className="col-span-4 grid grid-cols-1 gap-x-4 px-4 py-2 sm:px-6 lg:col-span-4 lg:grid-cols-subgrid lg:grid-rows-none lg:items-center">
+    <li className="col-span-5 grid grid-cols-1 gap-x-4 px-4 py-2 sm:px-6 lg:col-span-5 lg:grid-cols-subgrid lg:grid-rows-none lg:items-center">
       {/* Title + badges (always first) */}
       <div className="flex min-w-0 items-center lg:col-start-1">
         <div className="flex min-w-0 flex-wrap items-center gap-2 lg:flex-nowrap">
@@ -126,6 +127,11 @@ const ChatListItem = (props: Chat) => {
                 </span>
               </>
             )}
+          </div>
+
+          {/* Delete */}
+          <div className="flex items-center lg:col-start-5">
+            <DeleteChat chat={props} />
           </div>
         </div>
       </div>
@@ -188,7 +194,7 @@ export const ChatList = ({ queryParams, onUpdateSort }: ChatListProps) => {
             />
           </div>
           <div className="-mx-4 bg-white shadow sm:mx-0 sm:rounded-lg">
-            <ul className="grid grid-cols-[1fr_min-content_min-content_min-content] divide-y divide-gray-200">
+            <ul className="grid grid-cols-[1fr_min-content_min-content_min-content_min-content] divide-y divide-gray-200">
               {data.pages.map((page, index) => (
                 <Fragment key={index}>
                   {page.data.map((chat) => (

--- a/src/features/chats/components/DeleteChat.tsx
+++ b/src/features/chats/components/DeleteChat.tsx
@@ -1,0 +1,143 @@
+import { mdiTrashCan } from "@mdi/js";
+import { useState } from "react";
+
+import { Button, DisclosureDialog } from "components/Elements";
+import { useDeleteChat } from "features/chats";
+
+import { useNotificationStore } from "stores/notifications";
+import { Chat } from "types";
+
+type DeleteChatProps = {
+  chat: Chat;
+};
+
+export function DeleteChat({ chat }: DeleteChatProps) {
+  const { addNotification } = useNotificationStore();
+  const [leave, setLeave] = useState(true);
+  const [del, setDel] = useState(false);
+  const [attachments, setAttachments] = useState(false);
+
+  const deleteChatMutation = useDeleteChat({
+    mutationConfig: {
+      onSuccess: () => {
+        addNotification({
+          type: "success",
+          title: "Chat deleted.",
+        });
+      },
+    },
+  });
+
+  return (
+    <DisclosureDialog
+      triggerButton={(open) => (
+        <Button
+          size="sm"
+          variant="secondary"
+          startIcon={mdiTrashCan}
+          className="flex-shrink-0"
+          onClick={open}
+        >
+          <span>Delete</span>
+        </Button>
+      )}
+      title="Delete Chat"
+    >
+      {({ close }) => (
+        <div className="space-y-4">
+          <p className="text-sm text-gray-500">
+            Are you sure you want to delete &quot;{chat.title ?? chat.id}
+            &quot;?
+          </p>
+
+          <div className="space-y-3">
+            <label className="flex items-start gap-3">
+              <input
+                type="checkbox"
+                checked={leave}
+                onChange={(e) => setLeave(e.target.checked)}
+                className="mt-0.5 h-5 w-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <div>
+                <span className="font-medium text-gray-700">Leave</span>
+                <p className="text-sm text-gray-500">
+                  Leave the chat in Telegram
+                </p>
+              </div>
+            </label>
+
+            <label className="flex items-start gap-3">
+              <input
+                type="checkbox"
+                checked={del}
+                onChange={(e) => {
+                  setDel(e.target.checked);
+                  if (!e.target.checked) setAttachments(false);
+                }}
+                className="mt-0.5 h-5 w-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <div>
+                <span className="font-medium text-gray-700">Delete data</span>
+                <p className="text-sm text-gray-500">
+                  Delete all chat data (record, messages, metrics, vectorized
+                  index)
+                </p>
+              </div>
+            </label>
+
+            <label className="flex items-start gap-3">
+              <input
+                type="checkbox"
+                checked={attachments}
+                disabled={!del}
+                onChange={(e) => setAttachments(e.target.checked)}
+                className="mt-0.5 h-5 w-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 disabled:opacity-50"
+              />
+              <div>
+                <span className="font-medium text-gray-700">
+                  Delete attachments
+                </span>
+                <p className="text-sm text-gray-500">
+                  Also delete attachment files from storage (requires delete
+                  data)
+                </p>
+              </div>
+            </label>
+          </div>
+
+          <Button
+            type="button"
+            variant="danger"
+            disabled={!leave && !del}
+            isLoading={deleteChatMutation.isPending}
+            onClick={async () => {
+              try {
+                await deleteChatMutation.mutateAsync({
+                  id: chat.id!,
+                  leave,
+                  delete: del,
+                  attachments,
+                });
+                close();
+              } catch (error) {
+                console.error(error);
+              }
+            }}
+            className="w-full"
+          >
+            Confirm
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            className="w-full"
+            onClick={close}
+            data-autofocus
+          >
+            Cancel
+          </Button>
+        </div>
+      )}
+    </DisclosureDialog>
+  );
+}

--- a/src/features/chats/components/index.ts
+++ b/src/features/chats/components/index.ts
@@ -2,3 +2,4 @@ export * from "./ChatList";
 export * from "./ChatLink";
 export * from "./ChatSortSelector";
 export * from "./ChatTags";
+export * from "./DeleteChat";

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -412,11 +412,7 @@ export interface paths {
         get: operations["list_chats_chats_get"];
         put?: never;
         post?: never;
-        /**
-         * Delete Chats
-         * @description ⚠️ WARNING: Ensure clients have left these chats before deletion, or scraping will automatically restart. This deletes chat records, message indices, metrics, vectorized indices and, if requested, storage objects (attachments).
-         */
-        delete: operations["delete_chats_chats_delete"];
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -462,7 +458,23 @@ export interface paths {
          */
         put: operations["update_chat_chats__id__put"];
         post?: never;
-        delete?: never;
+        /**
+         * Delete Chat
+         * @description Leave and/or delete a single chat and its related data.
+         *
+         *     - `leave`: Leave the chat in Telegram
+         *     - `delete`: Delete all chat data (record, messages, metrics, vectorized index)
+         *     - `attachments`: Also delete attachment files from storage — requires `delete=true`
+         *
+         *     Leave is always performed before deletion to prevent new data arriving
+         *     during the deletion process.
+         *
+         *     Attachment deletion: after the chat's messages are removed, any storage file
+         *     that is no longer referenced by any message in the database is deleted. This
+         *     means files shared with other chats (e.g. via forwarding) are kept, but files
+         *     exclusively used by this chat are removed.
+         */
+        delete: operations["delete_chat_chats__id__delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -673,26 +685,6 @@ export interface paths {
          * @description Return classification evaluation results
          */
         get: operations["evaluate_evaluation_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/storage/{bucket_name}/{object_name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get File
-         * @description Retrieve and stream a file from object storage (S3/MinIO).
-         */
-        get: operations["get_file_storage__bucket_name___object_name__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1115,17 +1107,16 @@ export interface components {
             phone_code: string;
         };
         /**
-         * DeleteChatsRequest
-         * @description Request body for deleting multiple chats.
+         * DeleteChatResponse
+         * @description Response for the delete chat endpoint.
          */
-        DeleteChatsRequest: {
-            /** Chat Ids */
-            chat_ids: number[];
-            /**
-             * Delete Attachments
-             * @default false
-             */
-            delete_attachments: boolean;
+        DeleteChatResponse: {
+            /** Leave Results */
+            leave_results?: components["schemas"]["LeaveChatResult"][] | null;
+            /** Deleted Storage Objects */
+            deleted_storage_objects?: number | null;
+            /** Errors */
+            errors?: string[] | null;
         };
         /** ErrorModel */
         ErrorModel: {
@@ -1217,6 +1208,18 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
+        };
+        /**
+         * LeaveChatResult
+         * @description Result of leaving a chat for a single client.
+         */
+        LeaveChatResult: {
+            /** Client Id */
+            client_id: string;
+            /** Success */
+            success: boolean;
+            /** Message */
+            message?: string | null;
         };
         /** ListMessagesParams */
         ListMessagesParams: {
@@ -2807,41 +2810,6 @@ export interface operations {
             };
         };
     };
-    delete_chats_chats_delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["DeleteChatsRequest"];
-            };
-        };
-        responses: {
-            /** @description Delete multiple chats and their related data */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     get_chats_stats_chats_stats_get: {
         parameters: {
             query?: {
@@ -2932,6 +2900,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChatOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_chat_chats__id__delete: {
+        parameters: {
+            query?: {
+                leave?: boolean;
+                delete?: boolean;
+                attachments?: boolean;
+            };
+            header?: never;
+            path: {
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Leave and/or delete a chat and its data */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeleteChatResponse"];
                 };
             };
             /** @description Validation Error */
@@ -3299,54 +3302,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["EvaluationResult"];
-                };
-            };
-        };
-    };
-    get_file_storage__bucket_name___object_name__get: {
-        parameters: {
-            query?: {
-                attachment?: boolean;
-            };
-            header?: never;
-            path: {
-                bucket_name: string;
-                object_name: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Requested file from storage. Can be of any media type. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": unknown;
-                };
-            };
-            /** @description Any other error why the file could not be fetched. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description The bucket or file was not found. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -90,6 +90,9 @@ export type ListMessagesParams =
 export type GlobalMetricsResponse =
   API.paths["/metrics"]["get"]["responses"]["200"]["content"]["application/json"];
 
+export type DeleteChatResponse =
+  API.components["schemas"]["DeleteChatResponse"];
+
 export type FastApiError = API.components["schemas"]["ErrorModel"];
 
 export type SortBy = ChatSortBy | MessageSortBy | UserSortBy | ClientSortBy;


### PR DESCRIPTION
This pull request introduces a new feature that allows users to delete individual chats from the chat list, including options to leave the chat in Telegram, delete all chat data, and remove attachments. It also updates the API types to support this new functionality and removes the now-obsolete multi-chat deletion endpoint. The UI is updated to include a delete button for each chat, and the relevant API hooks and components are implemented.

**New Chat Deletion Functionality**

- Added a `DeleteChat` component with a confirmation dialog, allowing users to leave a chat, delete chat data, and optionally delete attachments. The component provides user feedback and disables inappropriate options (e.g., attachments deletion without data deletion). (`src/features/chats/components/DeleteChat.tsx`)
- Integrated the `DeleteChat` button into each chat row in the chat list UI, updated grid layouts to accommodate the new column, and exported the component for use. (`src/features/chats/components/ChatList.tsx`, `src/features/chats/components/index.ts`) [[1]](diffhunk://#diff-cdbe72bc87d54d6b59875a81d13433553f22903951126a2f6b770bf7f4f793dbR18) [[2]](diffhunk://#diff-cdbe72bc87d54d6b59875a81d13433553f22903951126a2f6b770bf7f4f793dbL68-R69) [[3]](diffhunk://#diff-cdbe72bc87d54d6b59875a81d13433553f22903951126a2f6b770bf7f4f793dbR131-R135) [[4]](diffhunk://#diff-cdbe72bc87d54d6b59875a81d13433553f22903951126a2f6b770bf7f4f793dbL191-R197) [[5]](diffhunk://#diff-06f35ed43b6c42de2b04a0807997e31373f6756132e7ff8e32310d1b14e6744bR5)

**API Integration and Hooks**

- Implemented the `deleteChat` API function and a `useDeleteChat` React Query hook, which handles chat deletion and triggers a refetch of the chat list on success. (`src/features/chats/api/deleteChat.ts`, `src/features/chats/api/index.ts`) [[1]](diffhunk://#diff-8812ac7407dbf770ec586ad2bf45dc875996a081aebe22569d2dd05d19270653R1-R41) [[2]](diffhunk://#diff-e0a533e8a301454883dec0704062ca273a014e6704ec0874b6f51211556db630R1)

**API Types and Schema Updates**

- Updated API type definitions to support single chat deletion, including new request parameters and a detailed `DeleteChatResponse` schema. Removed the old multi-chat deletion endpoint and related types. (`src/types/api.ts`, `src/types/index.ts`) [[1]](diffhunk://#diff-bdd1d2421dd8a9a482f33554738b04c31fda4e51cefcf0270349c50e31729ab7L415-R415) [[2]](diffhunk://#diff-bdd1d2421dd8a9a482f33554738b04c31fda4e51cefcf0270349c50e31729ab7L465-R477) [[3]](diffhunk://#diff-bdd1d2421dd8a9a482f33554738b04c31fda4e51cefcf0270349c50e31729ab7L684-L703) [[4]](diffhunk://#diff-bdd1d2421dd8a9a482f33554738b04c31fda4e51cefcf0270349c50e31729ab7L1118-R1119) [[5]](diffhunk://#diff-bdd1d2421dd8a9a482f33554738b04c31fda4e51cefcf0270349c50e31729ab7R1212-R1223) [[6]](diffhunk://#diff-bdd1d2421dd8a9a482f33554738b04c31fda4e51cefcf0270349c50e31729ab7L2810-L2844) [[7]](diffhunk://#diff-bdd1d2421dd8a9a482f33554738b04c31fda4e51cefcf0270349c50e31729ab7R2916-R2950) [[8]](diffhunk://#diff-bdd1d2421dd8a9a482f33554738b04c31fda4e51cefcf0270349c50e31729ab7L3306-L3353) [[9]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R93-R95)

These changes collectively enable safe, flexible, and user-friendly deletion of individual chats from the frontend, with robust API support and improved type safety.
[Copilot is generating a summary...]