### PR TITLE
Saved searches: state-dependent unread counters and formatted dashboard numbers

### DIFF
--- a/src/components/Elements/TrendList/TrendList.tsx
+++ b/src/components/Elements/TrendList/TrendList.tsx
@@ -33,7 +33,9 @@ export function StatsEntryTrendList({
         ) : (
           <li key={entry.value} className="flex justify-between gap-4">
             <span className="truncate font-medium">{entry.value} </span>
-            <span className="font-bold">{entry.count}</span>
+            <span className="font-bold tabular-nums">
+              {formatNumber(entry.count)}
+            </span>
           </li>
         )
       }
@@ -91,7 +93,9 @@ export function SearchQueryTrendList({
               {entry.value}
             </Link>
           )}
-          <span className="font-bold">{entry.count}</span>
+          <span className="font-bold tabular-nums">
+            {formatNumber(entry.count)}
+          </span>
         </li>
       )}
     </StatsEntryTrendList>
@@ -149,7 +153,9 @@ export function AttachmentTypesTrendList({
                 .join(" ")}
             </Link>
           )}
-          <span className="font-bold">{entry.count}</span>
+          <span className="font-bold tabular-nums">
+            {formatNumber(entry.count)}
+          </span>
         </li>
       )}
     </StatsEntryTrendList>
@@ -183,7 +189,9 @@ export function TagsTrendList({
           >
             {entry.value}
           </Link>
-          <span className="font-bold">{entry.count}</span>
+          <span className="font-bold tabular-nums">
+            {formatNumber(entry.count)}
+          </span>
         </li>
       )}
     </StatsEntryTrendList>

--- a/src/components/Elements/TrendList/TrendList.tsx
+++ b/src/components/Elements/TrendList/TrendList.tsx
@@ -1,10 +1,12 @@
 import { mdiCounter, mdiTrophyOutline } from "@mdi/js";
+import clsx from "clsx";
 import { startCase } from "lodash";
 import { Link } from "react-router-dom";
 
 import { ListBox, ListBoxProps } from "components/Elements";
 
 import { SavedSearch, SavedSearchesMessagesCountDict, StatsEntry } from "types";
+import { formatNumber } from "utils/formatNumber";
 
 // ListBoxProps<StatsEntry> with optional children
 type StatsEntryTrendListProps = Omit<ListBoxProps<StatsEntry>, "children"> &
@@ -228,7 +230,7 @@ export function SavedSearchesMessagesCountTrendList({
       length={length}
     >
       {(savedSearchCounts) => (
-        <li key={savedSearchCounts.name} className="flex gap-4">
+        <li key={savedSearchCounts.name} className="flex items-center gap-4">
           <span className="flex-1 truncate font-medium">
             <Link
               className="hover:underline"
@@ -237,11 +239,18 @@ export function SavedSearchesMessagesCountTrendList({
               {savedSearchCounts.name}
             </Link>
           </span>
-          <span className="flex-shrink-0 font-bold text-green-600">
-            {savedSearchCounts.countUnread}{" "}
+          <span
+            className={clsx(
+              "w-14 flex-shrink-0 text-right font-bold tabular-nums",
+              savedSearchCounts.countUnread > 0
+                ? "text-green-600"
+                : "text-gray-400",
+            )}
+          >
+            {formatNumber(savedSearchCounts.countUnread ?? 0)}
           </span>
-          <span className="flex-shrink-0 font-bold">
-            {savedSearchCounts.countTotal}
+          <span className="w-14 flex-shrink-0 text-right font-bold tabular-nums">
+            {formatNumber(savedSearchCounts.countTotal ?? 0)}
           </span>
         </li>
       )}

--- a/src/features/saved-searches/components/MessagesCount.tsx
+++ b/src/features/saved-searches/components/MessagesCount.tsx
@@ -2,17 +2,15 @@ import { mdiMessage, mdiMessageBadge } from "@mdi/js";
 import Icon from "@mdi/react";
 import clsx from "clsx";
 
-import { Spinner } from "components/Elements";
+import { Badge, Spinner } from "components/Elements";
 import { formatNumber } from "utils/formatNumber";
 
 const variants = {
   total: {
-    className: "text-gray-600",
     icon: mdiMessage,
     description: "Messages",
   },
   unread: {
-    className: "text-green-600",
     icon: mdiMessageBadge,
     description: "Unread Messages",
   },
@@ -22,34 +20,49 @@ export function MessagesCount({
   count,
   variant = "total",
   status,
+  className,
 }: {
   count?: number;
   variant?: keyof typeof variants;
   status: "error" | "success" | "pending";
+  className?: string;
 }) {
   const countFormatted = formatNumber(count ?? 0);
+  const isHighlighted = variant === "unread" && (count ?? 0) > 0;
+  const colorClassName = isHighlighted ? "text-green-600" : "text-gray-600";
 
   return (
     <div
-      className={clsx("flex items-center space-x-1", {
-        "opacity-50": status === "error",
-      })}
+      className={clsx(
+        "flex items-center space-x-1",
+        { "opacity-50": status === "error" },
+        className,
+      )}
       title={countFormatted + " " + variants[variant].description}
     >
       {variants[variant].icon && (
         <Icon
           path={variants[variant].icon}
           size={1}
-          className={variants[variant].className}
+          className={colorClassName}
         />
       )}
 
       {status === "pending" ? (
         <Spinner size="sm" />
       ) : status === "success" ? (
-        <span className={clsx("font-medium", variants[variant].className)}>
-          {countFormatted}
-        </span>
+        variant === "unread" ? (
+          <Badge
+            label={countFormatted}
+            variant={isHighlighted ? "green" : "gray"}
+            size="md"
+            className="tabular-nums"
+          />
+        ) : (
+          <span className={clsx("font-medium tabular-nums", colorClassName)}>
+            {countFormatted}
+          </span>
+        )
       ) : (
         "?"
       )}

--- a/src/features/saved-searches/components/SavedSearchList.tsx
+++ b/src/features/saved-searches/components/SavedSearchList.tsx
@@ -47,15 +47,17 @@ export function SavedSearchList() {
                       {savedSearch.name}
                     </Link>
                   </div>
-                  <div className="flex gap-4">
+                  <div className="flex items-center gap-4">
                     <MessagesCount
                       count={count_unread}
                       variant="unread"
                       status={messagesStatus}
+                      className="w-24"
                     />
                     <MessagesCount
                       count={count_total}
                       status={messagesStatus}
+                      className="w-24"
                     />
                     <DeleteSavedSearch savedSearch={savedSearch} />
                   </div>


### PR DESCRIPTION
- Saved-searches list: unread count as pill badge — green when unread > 0, gray when 0
- Dashboard saved-searches card: unread count text in green when > 0, muted gray when 0
- Counter columns aligned with fixed widths and tabular numerals
- All dashboard trend-list counts formatted with thousand separators

Verified in the browser; TypeScript passes.